### PR TITLE
Sort episode list by air date instead of local cache mtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,9 +376,14 @@
           }
         }
 
-        // Sort it by last modified
+        // Sort by episode air date (falling back to local cache mtime for
+        // entries with no DB match, since those have no ZFIRSTTIMEAVAILABLE)
         transcripts = Object.fromEntries(Object.entries(transcripts)
-          .sort(([, a], [, b]) => new Date(b.lastModified) - new Date(a.lastModified)));
+          .sort(([, a], [, b]) => {
+            const aTime = a.time > 0 ? a.time * 1000 : a.lastModified;
+            const bTime = b.time > 0 ? b.time * 1000 : b.lastModified;
+            return bTime - aTime;
+          }));
 
         // Iterate over it
         for (const transcript of Object.values(transcripts)) {


### PR DESCRIPTION
## Summary
- The list was sorted by `file.lastModified`, which reflects when the `.ttml` transcript was cached to disk locally, not when the episode aired. Since each card already displays the real air date (from `ZFIRSTTIMEAVAILABLE`), the visible dates and the sort order could disagree, making the order look arbitrary.
- Sorts by `transcript.time` when available, falling back to `lastModified` only for episodes with no matching database row (which have no air date to sort by).

## Test plan
- Verified against a real transcript cache with episodes spanning several podcasts; sort order now matches the displayed dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)